### PR TITLE
after_sign_in_path_for(resource) redirects users to their respective paths

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,6 +22,7 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     # return the path based on resource
     if resource.owner
+      @business = Business.find_by(user_id: resource.id)
       if resource.businesses.size > 0
         return business_path(@business)
       else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, except: :home
 
@@ -16,7 +15,6 @@ class ApplicationController < ActionController::Base
 
     # For additional in app/views/devise/registrations/edit.html.erb
     devise_parameter_sanitizer.permit(:account_update, keys: [:username])
-
   end
 
   protected
@@ -24,11 +22,11 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     # return the path based on resource
     if resource.owner
-      # if resource.owner.businesses
-          return business_path(@business)
-      # else
+      if resource.businesses.size > 0
+        return business_path(@business)
+      else
         return new_business_path
-      # end
+      end
     else
       return root_path
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
 
-
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!, except: :home
 
@@ -10,7 +9,7 @@ class ApplicationController < ActionController::Base
     # For additional fields in app/views/devise/registrations/new.html.erb
     # devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :email, :password])
     devise_parameter_sanitizer.permit(:sign_up) do |user_params|
-      user_params.permit({ owner: [] }, :first_name, :last_name, :email, :password, :password_confirmation)
+      user_params.permit(:first_name, :last_name, :email, :password, :password_confirmation, :owner)
     end
 
     devise_parameter_sanitizer.permit(:sign_in, keys: [:email, :password])
@@ -18,5 +17,20 @@ class ApplicationController < ActionController::Base
     # For additional in app/views/devise/registrations/edit.html.erb
     devise_parameter_sanitizer.permit(:account_update, keys: [:username])
 
+  end
+
+  protected
+
+  def after_sign_in_path_for(resource)
+    # return the path based on resource
+    if resource.owner
+      # if resource.owner.businesses
+          return business_path(@business)
+      # else
+        return new_business_path
+      # end
+    else
+      return root_path
+    end
   end
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,6 @@
                 input_html: { autocomplete: "first_name" }%>
     <%= f.input :email,
                 required: true,
-
                 input_html: { autocomplete: "email" }%>
     <%= f.input :password,
                 required: true,
@@ -23,6 +22,7 @@
     <%= f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
+    <%= f.input :owner %>
   </div>
 
   <div class="form-actions">


### PR DESCRIPTION
Define **after_sign_in_path_for(resource)** to redirect the users to the correct path based on their 'role' (normal user to homepage of normal website and owners of business to their personal profiles)